### PR TITLE
Updated Go version to 1.25 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hbelmiro/go-kube-get
 
-go 1.24.0
-
-toolchain go1.24.4
+go 1.25
 
 require (
 	golang.org/x/text v0.28.0


### PR DESCRIPTION
Resolves https://github.com/hbelmiro/go-kube-get/issues/12.